### PR TITLE
feat(*) lazy load api

### DIFF
--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -53,9 +53,11 @@ FILENAME=$TARGET/table_of_contents.lua
 echo "adding: $FILENAME"
 echo "return {" >> $FILENAME
 for f in "${file_list[@]}"; do
+  source_file=$SOURCE/apis/$f.normal.json
+  service_id=$(jq -r '.metadata.serviceId' $source_file | tr -d ' ')
   # replace . with - since . can't be in a Lua module name
   f=${f//./-}
-  echo '  "'"$f"'",' >> $FILENAME
+  echo '  "'"$service_id:$f"'",' >> $FILENAME
 done
 echo "}" >> $FILENAME
 


### PR DESCRIPTION
Reduce memory usage.

Similar to https://github.com/Kong/lua-resty-gcp/pull/7.

### Benchmark

```lua
setmetatable(_G, nil) -- disable global warnings

ngx.update_time()
local start = ngx.now()

collectgarbage()
print("before require: ", collectgarbage("count"))

local AWS = require("resty.aws")
local EnvironmentCredentials = require "resty.aws.credentials.EnvironmentCredentials"
print("after require: ", collectgarbage("count"))

local aws = AWS({ credentials = EnvironmentCredentials.new() })
print("after initializing: ", collectgarbage("count"))

local other = AWS({ credentials = EnvironmentCredentials.new() })
print("after creating another instance: ", collectgarbage("count"))

aws = nil
other = nil
collectgarbage("collect")
print("after garbage collection: ", collectgarbage("count"))

ngx.update_time()
print("duration: ", ngx.now() - start)
```

### `main` branch

```bash
resty tests/bench.lua | column -t -s :
before require                    199.5703125
after require                     39980.15234375
after initializing                32891.67578125
after creating another instance   33002.5390625
after garbage collection          31729.9765625
duration                          0.85700011253357
```

### This PR `fix/lazy_load_api`

```bash
resty tests/bench.lua | column -t -s :
before require                    199.5703125
after require                     731.447265625
after initializing                2439.0419921875
after creating another instance   2537.4130859375
after garbage collection          2003.59765625
duration                          0.019999980926514
```