### PR TITLE
fix: `latest` indicates the most recent service version

### DIFF
--- a/spec/01-generic/03-service_spec.lua
+++ b/spec/01-generic/03-service_spec.lua
@@ -1,3 +1,5 @@
+local tablex = require "pl.tablex"
+
 describe("service generator", function()
 
 
@@ -39,6 +41,22 @@ describe("service generator", function()
 
     local mesh = assert(AWS():AppMesh({ apiVersion = "2018-10-01", region = "us-east-1" }))
     assert.equal("2018-10-01", mesh.config.apiVersion)
+  end)
+
+
+  it("'latest' indicates the most recent service version", function()
+    -- Find latest version from table of contents
+    local list = require("resty.aws.raw-api.table_of_contents")
+    local service_list = tablex.filter(list, function(v) return v:find("DynamoDB:") end)
+    table.sort(service_list)
+    local _, _, latest_version = service_list[#service_list]:match("^(.-)%:(.-)%-(%d%d%d%d%-%d%d%-%d%d)$")
+
+    local dynamoDB = assert(AWS():DynamoDB({ apiVersion = "latest", region = "us-east-1" }))
+    assert.equal(latest_version, dynamoDB.config.apiVersion)
+
+    -- use latest version by default
+    dynamoDB = assert(AWS():DynamoDB({ region = "us-east-1" }))
+    assert.equal(latest_version, dynamoDB.config.apiVersion)
   end)
 
 

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -94,7 +94,8 @@ do
     local service_table = aws_config.api[service_id] or {}
     service_table[version] = module_name
 
-    local sorted_versions = tablex.keys(service_table)
+    local sorted_versions = tablex.filter(tablex.keys(service_table),
+                              function(v) return v ~= "latest" end)
     table.sort(sorted_versions)
 
     service_table.latest = service_table[sorted_versions[#sorted_versions]]


### PR DESCRIPTION
### Summary

Fix an issue where `latest` not indicates the most recent service version.