### PR TITLE
fix(rds): fix rds signer cannot be used in init phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+### Unreleased
+
+- fix: fix the rds signer cannot be used in init phase.
+  [#50](https://github.com/Kong/lua-resty-aws/pull/50)
+
 ### 1.2.0 (1-Mar-2023)
 
 - **IMPORTANT-IMPORTANT-IMPORTANT** feat: enable TLS name verification. This might

--- a/src/resty/aws/service/rds/signer.lua
+++ b/src/resty/aws/service/rds/signer.lua
@@ -6,7 +6,7 @@
 -- RDS services created will get a `Signer` method to create an instance. The `Signer` will
 -- inherit its configuration from the `AWS` instance (not from the RDS instance!).
 
-local httpc = require("resty.http").new()
+local httpc = require("resty.luasocket.http")
 local presign_awsv4_request = require("resty.aws.request.signatures.presign")
 
 local RDS_IAM_AUTH_EXPIRE_TIME = 15 * 60


### PR DESCRIPTION
This PR fixes a problem that the rds signer cannot be used in init phase.

```
2023/04/17 13:11:45 [error] 784916#0: init_by_lua error: ./kong/globalpatches.lua:576: no request found
stack traceback:
        [C]: in function 'old_tcp'
        ./kong/globalpatches.lua:576: in function 'ngx_socket_tcp'
        ...ee/bazel-bin/build/kong-dev/share/lua/5.1/resty/http.lua:133: in function 'new'
        .../kong-dev/share/lua/5.1/resty/aws/service/rds/signer.lua:9: in main chunk
        [C]: in function 'require'
        ...azel-bin/build/kong-dev/share/lua/5.1/resty/aws/init.lua:467: in function 'RDS'
        ./kong/db/strategies/postgres/iam_token_handler.lua:32: in function 'init'
        ./kong/db/strategies/postgres/connector.lua:1071: in function 'new'
        ./kong/db/strategies/init.lua:37: in function 'new'
        ./kong/db/init.lua:95: in function 'new'
        ./kong/init.lua:624: in function 'init'
        init_by_lua:3: in main chunk
```

I believe it should because of the `new()` being called here since I don't really need a real socket in the rds signer. However, to keep consistent with other usages in the repo, I'll replace `resty.http` with `luasockets.http`


Tested locally inside Kong's integration.