### PR TITLE
fix: add SharedFileCredentials into rockspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Release process:
 
 ### Unreleased
 
+- fix: add the SharedFileCredentials into rockspec so it can be packed and used correctly.
+  [#53](https://github.com/Kong/lua-resty-aws/pull/53)
+
+### 1.2.1 (24-Apr-2023)
+
 - fix: fix the rds signer cannot be used in init phase.
   [#50](https://github.com/Kong/lua-resty-aws/pull/50)
 

--- a/lua-resty-aws-dev-1.rockspec.template
+++ b/lua-resty-aws-dev-1.rockspec.template
@@ -49,6 +49,7 @@ build = {
     ["resty.aws.credentials.CredentialProviderChain"]         = "src/resty/aws/credentials/CredentialProviderChain.lua",
     ["resty.aws.credentials.EC2MetadataCredentials"]          = "src/resty/aws/credentials/EC2MetadataCredentials.lua",
     ["resty.aws.credentials.EnvironmentCredentials"]          = "src/resty/aws/credentials/EnvironmentCredentials.lua",
+    ["resty.aws.credentials.SharedFileCredentials"]           = "src/resty/aws/credentials/SharedFileCredentials.lua",
     ["resty.aws.credentials.RemoteCredentials"]               = "src/resty/aws/credentials/RemoteCredentials.lua",
     ["resty.aws.credentials.TokenFileWebIdentityCredentials"] = "src/resty/aws/credentials/TokenFileWebIdentityCredentials.lua",
 


### PR DESCRIPTION
## Summary

This PR adds the SharedFileCredentials into rockspec so it can be packed and used correctly.

Currently it will not be installed by luarock

FTI-5045