### PR TITLE
Some fixes for AWS/S3

### DIFF
--- a/src/resty/aws/request/execute.lua
+++ b/src/resty/aws/request/execute.lua
@@ -12,7 +12,7 @@ local json_decode = require("cjson.safe").new().decode
 --
 -- Input parameters:
 -- * signed_request table
-local function execute_request(signed_request)
+local function execute_request(signed_request, return_raw_body)
 
   local httpc = http.new()
   httpc:set_timeout(60000)
@@ -22,7 +22,7 @@ local function execute_request(signed_request)
     port = signed_request.port,
     scheme = signed_request.tls and "https" or "http",
     ssl_server_name = signed_request.host,
-    ssl_verify = true,
+    ssl_verify = false,
   }
   if not ok then
     return nil, ("failed to connect to '%s://%s:%s': %s"):format(
@@ -49,6 +49,17 @@ local function execute_request(signed_request)
 
   local body do
     if response.has_body then
+      if return_raw_body then
+        return {
+          httpc = httpc,
+          status = response.status,
+          reason = response.reason,
+          headers = response.headers,
+          has_body = response.has_body,
+          body_reader = response.body_reader,
+          read_body = response.read_body,
+        }
+      end
       body, err = response:read_body()
       if not body then
         return nil, ("failed reading response body from '%s:%s': %s"):format(

--- a/src/resty/aws/request/execute.lua
+++ b/src/resty/aws/request/execute.lua
@@ -22,7 +22,7 @@ local function execute_request(signed_request, return_raw_body)
     port = signed_request.port,
     scheme = signed_request.tls and "https" or "http",
     ssl_server_name = signed_request.host,
-    ssl_verify = false,
+    ssl_verify = true,
   }
   if not ok then
     return nil, ("failed to connect to '%s://%s:%s': %s"):format(

--- a/src/resty/aws/request/validate.lua
+++ b/src/resty/aws/request/validate.lua
@@ -435,6 +435,9 @@ local validators do
     type = always_pass,
     deprecated = always_pass,
     box = always_pass,
+    locationName = always_pass,
+    location = always_pass,
+    deprecatedMessage = always_pass,
   },ops_mt)
 
 


### PR DESCRIPTION
I discovered that operations without empty description of `operation.input` does not work at all. I've added `if` into `aws/init.lua` and `aws/request/build.lua`

- validate operation.input first before validate against it. s3/listBuckets does not accept any input.validator

`s3_patch` (`aws/init.lua`) seems to be not quite well written. When we change `request.host` we should change `request.headers.Host` as well, because of the signature. Also, operations such as `listObjectsV2` and other meta operations requires non-empty path.

- refix S3 fixes path: if path=="" we need to restore path="/"

The last part is not quite good :( It would be nice if we could parse xml output into Lua tables, we have `operation.output` descriptions for it. To do that we need to distinguish streaming content and API responses.

Streaming content (`GetObject` mostly, maybe `GetObjectTorrent`) it would be better to not read entire body into Lua memory, but provide `body_reader` from `resty.http` instead. Although I'm not sure that this behaviour should be fixed the way I did it
- return raw body reader if operation output expects blob or streaming content

P.S. raw-api contains 17 `"streaming":true` lines, but necessarily all of the Outputs