### PR TITLE
Fix assumeRole function name on STS

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+### Unreleased
+- fix: fix assumeRole function name on STS.
+  [#59](https://github.com/Kong/lua-resty-aws/pull/59)
+
 ### 1.2.2 (2-May-2023)
 
 - fix: add the SharedFileCredentials into rockspec so it can be packed and used correctly.

--- a/src/resty/aws/credentials/ChainableTemporaryCredentials.lua
+++ b/src/resty/aws/credentials/ChainableTemporaryCredentials.lua
@@ -104,7 +104,7 @@ end
 -- updates credentials.
 -- @return success, or nil+err
 function ChainedTemporaryCredentials:refresh()
-  local result, err = self.sts:AssumeRole(self.params)
+  local result, err = self.sts:assumeRole(self.params)
   if not result then
     return nil, err
   end


### PR DESCRIPTION
Fixes an error: 
```
key 'AssumeRole' not found, did you mean 'assumeRole'?
```

@Tieske - I was hoping to work on [this Kong issue](https://github.com/Kong/kong/issues/7638) but need this fixed and released before ChainableTemporaryCredentials is usable.