### PR TITLE
fix(*): fix sts regional endpoint support

### DIFF
--- a/spec/01-generic/02-aws_spec.lua
+++ b/spec/01-generic/02-aws_spec.lua
@@ -4,7 +4,16 @@ describe("AWS main instance", function()
   local AWS
 
   setup(function()
+    package.loaded["resty.aws.request.execute"] = function ()
+      return {
+        status = 200,
+        reason = "OK",
+        headers = {},
+        body = ""
+      }
+    end
     AWS = require "resty.aws"
+    -- execute_request = require "resty.aws.request.execute"
   end)
 
   teardown(function()
@@ -55,6 +64,32 @@ describe("AWS main instance", function()
   it("gets methods for services, spaces removed from serviceId", function()
     local aws = AWS()
     assert.is.Function(aws.AppMesh) -- serviceId = "App Mesh"
+  end)
+
+  it("support sts regional endpoint inject and only inject once", function()
+    local aws = AWS({
+      region = "eu-central-1",
+      stsRegionalEndpoints = "regional",
+    })
+
+    aws.config.credentials = aws:Credentials {
+      accessKeyId = "test_id",
+      secretAccessKey = "test_key",
+    }
+
+    assert.is.table(aws.config)
+    local sts, err = aws:STS()
+    local _, err = sts:assumeRole {
+      RoleArn = "aws:arn::XXXXXXXXXXXXXXXXX:test123",
+      RoleSessionName = "aws-test",
+    }
+    assert.same("https://sts.eu-central-1.amazonaws.com", sts.config.endpoint)
+
+    local _, err = sts:assumeRole {
+      RoleArn = "aws:arn::XXXXXXXXXXXXXXXXX:test123",
+      RoleSessionName = "aws-test",
+    }
+    assert.same("https://sts.eu-central-1.amazonaws.com", sts.config.endpoint)
   end)
 
 end)

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -312,9 +312,6 @@ local function generate_service_methods(service)
         return nil, operation_prefix .. " validation error: " .. tostring(err)
       end
 
-      -- generate request data and format it according to the protocol
-      local request = build_request(operation, self.config, params)
-
       -- implement stsRegionalEndpoints config setting,
       if service.api.metadata.serviceId == "STS"
         and service.config.stsRegionalEndpoints == "regional"
@@ -330,6 +327,9 @@ local function generate_service_methods(service)
           service.config._regionalEndpointInjected = true
         end
       end
+
+      -- generate request data and format it according to the protocol
+      local request = build_request(operation, self.config, params)
 
       local old_sig
       if (unsigned[service.api.metadata.serviceId] or {})[operation.name] then


### PR DESCRIPTION
## Summary

The sts regional endpoint inject happens after `build_request` which means that when you called STS service with `AWS_STS_REGIONAL_ENDPOINT=regional` the first time, it will not work. This PR fixes that behaviour and also adds tests to check regional endpoint injection work as expected.

