### PR TITLE
fix(*): fix AWS_CONTAINER_CREDENTIALS_FULL_URI parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+### Unreleased
+
+- fix: fix AWS_CONTAINER_CREDENTIALS_FULL_URI parsing.
+  [#65](https://github.com/Kong/lua-resty-aws/pull/65)
+
 ### 1.2.3 (20-Jul-2023)
 
 - fix: fix assumeRole function name on STS.

--- a/spec/03-credentials/04-RemoteCredentials_spec.lua
+++ b/spec/03-credentials/04-RemoteCredentials_spec.lua
@@ -50,7 +50,6 @@ describe("RemoteCredentials", function()
   end)
 
 
-
   it("fetches credentials", function()
     local cred = RemoteCredentials:new()
     local success, key, secret, token = cred:get()
@@ -60,4 +59,29 @@ describe("RemoteCredentials", function()
     assert.equal("token", token)
   end)
 
+end)
+
+
+describe("RemoteCredentials with customized full URI", function ()
+  it("fetches credentials", function ()
+    local RemoteCredentials
+
+    restore()
+    restore.setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "http://localhost:12345/test/path")
+
+    local _ = require("resty.aws.config").global -- load config before mocking http client
+    package.loaded["resty.luasocket.http"] = http
+
+    RemoteCredentials = require "resty.aws.credentials.RemoteCredentials"
+    finally(function()
+      restore()
+    end)
+
+    local cred = RemoteCredentials:new()
+    local success, key, secret, token = cred:get()
+    assert.equal(true, success)
+    assert.equal("access", key)
+    assert.equal("secret", secret)
+    assert.equal("token", token)
+  end)
 end)

--- a/src/resty/aws/credentials/RemoteCredentials.lua
+++ b/src/resty/aws/credentials/RemoteCredentials.lua
@@ -48,7 +48,7 @@ local FullUri do
       end
 
       if (not FULL_URI_UNRESTRICTED_PROTOCOLS[parsed_url.scheme]) and
-          (not FULL_URI_ALLOWED_HOSTNAMES[parsed_url.hostname]) then
+          (not FULL_URI_ALLOWED_HOSTNAMES[parsed_url.host]) then
             return nil, 'Unsupported hostname: AWS.RemoteCredentials only supports '
                   .. table.concat(FULL_URI_ALLOWED_HOSTNAMES, ',') .. ' for '
                   .. parsed_url.scheme .. '; ' .. parsed_url.scheme .. '://'


### PR DESCRIPTION
The RemoteCredential does not support a full URI with port number now, the error log shows as follow:
```
2023/07/27 15:48:41 [debug] 46876#0: [lua] RemoteCredentials.lua:70: Failed to construct RemoteCredentials url: Unsupported hostname: AWS.RemoteCredentials only supports localhost,127.0.0.1 for http; http://localhost requested.
```

It seems that the code is using wrong reference for host, it should be `host` instead of `hostname`.

The document of socket.url.parse: 
```
url.parse(url, default)

Parses an URL given as a string into a Lua table with its components.

Url is the URL to be parsed. If the default table is present, it is used to store the parsed fields. Only fields present in the URL are overwritten. Therefore, this table can be used to pass default values for each field.

The function returns a table with all the URL components:

parsed_url = {
  url = string,
  scheme = string,
  authority = string,
  path = string,
  params = string,
  query = string,
  fragment = string,
  userinfo = string,
  host = string,
  port = string,
  user = string,
  password = string
}
```