### PR TITLE
feat(*): support configure multiple network options

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,12 @@ Release process:
 
 - fix: fix AWS_CONTAINER_CREDENTIALS_FULL_URI parsing.
   [#65](https://github.com/Kong/lua-resty-aws/pull/65)
+- feat: support configure timeout on service request.
+  [#66](https://github.com/Kong/lua-resty-aws/pull/66)
+- feat: support configure keepalive idle time on service request connection.
+  [#66](https://github.com/Kong/lua-resty-aws/pull/66)
+- feat: support configure ssl verify on service request.
+  [#66](https://github.com/Kong/lua-resty-aws/pull/66)
 
 ### 1.2.3 (20-Jul-2023)
 

--- a/spec/02-requests/03-execute_spec.lua
+++ b/spec/02-requests/03-execute_spec.lua
@@ -1,3 +1,171 @@
-pending("No tests for execution yet", function()
+local restore = require "spec.helpers".restore
 
+describe("request execution", function()
+  local AWS, Credentials
+
+  setup(function()
+    restore()
+    AWS = require "resty.aws"
+    Credentials = require "resty.aws.credentials.Credentials"
+  end)
+
+  teardown(function()
+    AWS = nil
+    package.loaded["resty.aws"] = nil
+  end)
+
+  it("tls defaults to true", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.tls, true)
+  end)
+
+  it("support configuring tls false", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.tls = false
+    aws.config.dry_run = true
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.port, 80)
+    assert.same(request.tls, false)
+  end)
+
+  it("ssl verify defaults to true", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.ssl_verify, true)
+  end)
+
+  it("support configuring ssl verify false", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+    aws.config.ssl_verify = false
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.ssl_verify, false)
+  end)
+
+  it("support configure timeout", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+    aws.config.timeout = 123456000
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.timeout, 123456000)
+  end)
+
+  it("support configure keepalive idle timeout", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+    aws.config.keepalive_idle_timeout = 123456000
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(err, nil)
+    assert.same(request.keepalive_idle_timeout, 123456000)
+  end)
 end)

--- a/spec/02-requests/03-execute_spec.lua
+++ b/spec/02-requests/03-execute_spec.lua
@@ -66,31 +66,6 @@ describe("request execution", function()
     assert.same(request.tls, false)
   end)
 
-  it("ssl verify defaults to true", function ()
-    local config = {
-      region = "us-east-1"
-    }
-
-    config.credentials = Credentials:new({
-      accessKeyId = "teqst_id",
-      secretAccessKey = "test_key",
-    })
-
-    local aws = AWS(config)
-    aws.config.dry_run = true
-
-    local s3 = aws:S3()
-
-    assert.same(type(s3.getObject), "function")
-    local request, err = s3:getObject({
-      Bucket = "test-bucket",
-      Key = "test-key",
-    })
-
-    assert.same(err, nil)
-    assert.same(request.ssl_verify, true)
-  end)
-
   it("support configuring ssl verify false", function ()
     local config = {
       region = "us-east-1"

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -354,6 +354,9 @@ local function generate_service_methods(service)
 
       --print(require("pl.pretty").write(signed_request))
 
+      if self.config.dry_run then
+        return signed_request
+      end
       -- execute the request
       local response, err = execute_request(signed_request)
       if not response then

--- a/src/resty/aws/request/signatures/presign.lua
+++ b/src/resty/aws/request/signatures/presign.lua
@@ -133,7 +133,7 @@ local function presign_awsv4_request(config, request_data, service, region, expi
   -- for the client to use, so here we just keep aligned
   -- with v4 signing, if the user want to use the
   -- request object directly.
-  local ssl_verify = config.ssl_verify == nil or config.ssl_verify
+  local ssl_verify = config.ssl_verify
 
   local host = request_data.host
   local port = request_data.port

--- a/src/resty/aws/request/signatures/v4.lua
+++ b/src/resty/aws/request/signatures/v4.lua
@@ -77,7 +77,7 @@ local function prepare_awsv4_request(config, request_data)
   local timeout = config.timeout
   local keepalive_idle_timeout = config.keepalive_idle_timeout
   local tls = config.tls
-  local ssl_verify = config.ssl_verify == nil or config.ssl_verify
+  local ssl_verify = config.ssl_verify
 
   local host = request_data.host
   local port = request_data.port

--- a/src/resty/aws/request/signatures/v4.lua
+++ b/src/resty/aws/request/signatures/v4.lua
@@ -32,7 +32,10 @@ local ALGORITHM = "AWS4-HMAC-SHA256"
 --    note: for headers "Host" and "Authorization"; they will be used if
 --          provided, and not be overridden by the generated ones
 -- tbl.body: string, defaults to ""
+-- tbl.timeout: number socket timeout (in ms), defaults to 60000
+-- tbl.keepalive_idle_timeout: number keepalive idle timeout (in ms), no keepalive if nil
 -- tbl.tls: defaults to true (if nil)
+-- tbl.ssl_verify: defaults to true (if nil)
 -- tbl.port: defaults to 443 or 80 depending on 'tls'
 -- tbl.timestamp: number defaults to 'ngx.time()''
 -- tbl.global_endpoint: if true, then use "us-east-1" as signing region and different
@@ -71,7 +74,10 @@ local function prepare_awsv4_request(config, request_data)
     end
   end
 
+  local timeout = config.timeout
+  local keepalive_idle_timeout = config.keepalive_idle_timeout
   local tls = config.tls
+  local ssl_verify = config.ssl_verify == nil or config.ssl_verify
 
   local host = request_data.host
   local port = request_data.port
@@ -178,7 +184,10 @@ local function prepare_awsv4_request(config, request_data)
     --url = url,      -- "https://lambda.us-east-1.amazon.com:443/some/path?query1=val1"
     host = host,    -- "lambda.us-east-1.amazon.com"
     port = port,    -- 443
+    timeout = timeout,  -- 60000
+    keepalive_idle_timeout = keepalive_idle_timeout, -- 60000
     tls = tls,      -- true
+    ssl_verify = ssl_verify, -- true
     path = path or canonicalURI,             -- "/some/path"
     method = request_method,  -- "GET"
     query = query or canonical_querystring,  -- "query1=val1"


### PR DESCRIPTION
## Summary

This PR adds support for configuring multiple network options on service request, including:
- ssl_verify open or not
- TCP overall timeout
- TCP keepalive idle timeout - (https://github.com/openresty/lua-nginx-module#tcpsocksetkeepalive)

KAG-2242