### PR TITLE
feat(*): add http/https proxy support for service request

### DIFF
--- a/spec/02-requests/03-execute_spec.lua
+++ b/spec/02-requests/03-execute_spec.lua
@@ -143,4 +143,40 @@ describe("request execution", function()
     assert.same(err, nil)
     assert.same(request.keepalive_idle_timeout, 123456000)
   end)
+
+  it("support set proxy options", function ()
+    local config = {
+      region = "us-east-1"
+    }
+
+    config.credentials = Credentials:new({
+      accessKeyId = "teqst_id",
+      secretAccessKey = "test_key",
+    })
+
+    local proxy_opts = {
+      http_proxy = 'http://test-http-proxy:1234',
+      https_proxy = 'http://test-https-proxy:4321',
+      no_proxy = '127.0.0.1,localhost'
+    }
+
+    local aws = AWS(config)
+    aws.config.dry_run = true
+    aws.config.http_proxy = proxy_opts.http_proxy
+    aws.config.https_proxy = proxy_opts.https_proxy
+    aws.config.no_proxy = proxy_opts.no_proxy
+
+    local s3 = aws:S3()
+
+    assert.same(type(s3.getObject), "function")
+    local request, err = s3:getObject({
+      Bucket = "test-bucket",
+      Key = "test-key",
+    })
+
+    assert.same(type(request.proxy_opts), "table")
+    for k, v in pairs(proxy_opts) do
+      assert.same(request.proxy_opts[k], v)
+    end
+  end)
 end)

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -140,6 +140,11 @@ local env_vars = {
   -- Variables used in RemoteCredentials (and in the CredentialProviderChain)
   AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = { name = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", default = nil },
   AWS_CONTAINER_CREDENTIALS_FULL_URI = { name = "AWS_CONTAINER_CREDENTIALS_FULL_URI", default = nil },
+
+  -- HTTP/HTTPs proxy settings
+  HTTP_PROXY = { name = "HTTP_PROXY", default = nil },
+  HTTPS_PROXY = { name = "HTTPS_PROXY", default = nil },
+  NO_PROXY = { name = "NO_PROXY", default = nil },
 }
 
 -- populate the env vars with their values, or defaults

--- a/src/resty/aws/request/execute.lua
+++ b/src/resty/aws/request/execute.lua
@@ -23,6 +23,7 @@ local function execute_request(signed_request)
     scheme = signed_request.tls and "https" or "http",
     ssl_server_name = signed_request.host,
     ssl_verify = signed_request.ssl_verify,
+    proxy_opts = signed_request.proxy_opts,
   }
   if not ok then
     return nil, ("failed to connect to '%s://%s:%s': %s"):format(

--- a/src/resty/aws/request/signatures/presign.lua
+++ b/src/resty/aws/request/signatures/presign.lua
@@ -134,6 +134,11 @@ local function presign_awsv4_request(config, request_data, service, region, expi
   -- with v4 signing, if the user want to use the
   -- request object directly.
   local ssl_verify = config.ssl_verify
+  local proxy_opts = {
+    http_proxy = config.http_proxy,
+    https_proxy = config.https_proxy,
+    no_proxy = config.no_proxy,
+  }
 
   local host = request_data.host
   local port = request_data.port
@@ -260,6 +265,7 @@ local function presign_awsv4_request(config, request_data, service, region, expi
     keepalive_idle_timeout = keepalive_idle_timeout, -- 60000
     tls = tls,      -- true
     ssl_verify = ssl_verify, -- true
+    proxy_opts = proxy_opts, -- table
     path = path or canonicalURI,             -- "/some/path"
     method = request_method,  -- "GET"
     query = canonical_querystring,  -- "query1=val1"

--- a/src/resty/aws/request/signatures/v4.lua
+++ b/src/resty/aws/request/signatures/v4.lua
@@ -78,6 +78,11 @@ local function prepare_awsv4_request(config, request_data)
   local keepalive_idle_timeout = config.keepalive_idle_timeout
   local tls = config.tls
   local ssl_verify = config.ssl_verify
+  local proxy_opts = {
+    http_proxy = config.http_proxy,
+    https_proxy = config.https_proxy,
+    no_proxy = config.no_proxy,
+  }
 
   local host = request_data.host
   local port = request_data.port
@@ -188,6 +193,7 @@ local function prepare_awsv4_request(config, request_data)
     keepalive_idle_timeout = keepalive_idle_timeout, -- 60000
     tls = tls,      -- true
     ssl_verify = ssl_verify, -- true
+    proxy_opts = proxy_opts, -- table
     path = path or canonicalURI,             -- "/some/path"
     method = request_method,  -- "GET"
     query = query or canonical_querystring,  -- "query1=val1"


### PR DESCRIPTION
## Summary

This PR adds support for using HTTP/HTTPS proxy on service requests. Proxies that are defined in the environment variable will also take effect, to keep aligned with https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-proxy.html

Note that most of the credential fetch-related requests (except the one that hit STS) will not use this proxy deliberately, as I thought it is very rare for those environment-related requests to have a need to use proxy

KAG-1621
FTI-5242
#2