### PR TITLE
feat(*): EC2 metadata credential provider support IMDSv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Release process:
   [#69](https://github.com/Kong/lua-resty-aws/pull/69)
 - fix: fix proxy-related global config var name to lowercase.
   [#70](https://github.com/Kong/lua-resty-aws/pull/70)
+- feat: EC2 metadata credential provider support IMDSv2
+  [#71]https://github.com/Kong/lua-resty-aws/pull/71
 
 ### 1.2.3 (20-Jul-2023)
 

--- a/spec/03-credentials/02-EC2MetadataCredentials_spec.lua
+++ b/spec/03-credentials/02-EC2MetadataCredentials_spec.lua
@@ -4,40 +4,110 @@ require "resty.aws.config" -- load before mocking the http lib
 
 -- Mock for HTTP client
 local response = {} -- override in tests
-local http = {
-  new = function()
-    return {
-      connect = function() return true end,
-      close = function() return true end,
-      set_timeout = function() return true end,
-      set_timeouts = function() return true end,
-      request = function(self, opts)
-        if opts.path == "/latest/meta-data/iam/security-credentials/" then
-          return { -- the response for requesting the role name
-              status = 200,
-              read_body = function() return "the_role_name" end,
-            }
-        elseif opts.path == "/latest/meta-data/iam/security-credentials/the_role_name" then
-          return { -- the response for the credentials for the role
-              status = (response or {}).status or 200,
-              read_body = function() return json.encode {
-                  AccessKeyId = (response or {}).AccessKeyId or "access",
-                  SecretAccessKey = (response or {}).SecretAccessKey or "secret",
-                  Token = (response or {}).Token or "token",
-                  Expiration = (response or {}).Expiration or "2030-01-01T20:00:00Z",
-                }
-              end,
-            }
-        else
-          error("bad test path provided??? " .. tostring(opts.path))
-        end
-      end,
-    }
-  end,
-}
+
+describe("EC2MetadataCredentials ~ v2", function()
+  local http = {
+    new = function()
+      return {
+        connect = function() return true end,
+        close = function() return true end,
+        set_timeout = function() return true end,
+        set_timeouts = function() return true end,
+        request = function(self, opts)
+          if opts.path == "/latest/meta-data/iam/security-credentials/" then
+            return { -- the response for requesting the role name
+                status = 200,
+                read_body = function() return "the_role_name" end,
+              }
+          elseif opts.path == "/latest/meta-data/iam/security-credentials/the_role_name" then
+            return { -- the response for the credentials for the role
+                status = (response or {}).status or 200,
+                read_body = function() return json.encode {
+                    AccessKeyId = (response or {}).AccessKeyId or "access",
+                    SecretAccessKey = (response or {}).SecretAccessKey or "secret",
+                    Token = (response or {}).Token or "token",
+                    Expiration = (response or {}).Expiration or "2030-01-01T20:00:00Z",
+                  }
+                end,
+              }
+          elseif opts.path == "/latest/api/token" and opts.method == "PUT" then
+            return {
+                status = 200,
+                read_body = function() return "the_token" end,
+              }
+          else
+            error("bad test path provided??? " .. tostring(opts.path))
+          end
+        end,
+      }
+    end,
+  }
+
+  local EC2MetadataCredentials
+
+  setup(function()
+    package.loaded["resty.luasocket.http"] = http
+  end)
+
+  teardown(function()
+    package.loaded["resty.luasocket.http"] = nil
+  end)
+
+  before_each(function()
+    package.loaded["resty.aws.credentials.EC2MetadataCredentials"] = nil
+    EC2MetadataCredentials = require "resty.aws.credentials.EC2MetadataCredentials"
+  end)
 
 
-describe("EC2MetadataCredentials", function()
+
+  it("fetches credentials", function()
+    local cred = EC2MetadataCredentials:new()
+    local success, key, secret, token = cred:get()
+    assert.equal("access", key)
+    assert.equal(true, success)
+    assert.equal("secret", secret)
+    assert.equal("token", token)
+  end)
+
+end)
+
+describe("EC2MetadataCredentials ~ v1", function()
+  local http = {
+    new = function()
+      return {
+        connect = function() return true end,
+        close = function() return true end,
+        set_timeout = function() return true end,
+        set_timeouts = function() return true end,
+        request = function(self, opts)
+          if opts.path == "/latest/meta-data/iam/security-credentials/" then
+            return { -- the response for requesting the role name
+                status = 200,
+                read_body = function() return "the_role_name" end,
+              }
+          elseif opts.path == "/latest/meta-data/iam/security-credentials/the_role_name" then
+            return { -- the response for the credentials for the role
+                status = (response or {}).status or 200,
+                read_body = function() return json.encode {
+                    AccessKeyId = (response or {}).AccessKeyId or "access",
+                    SecretAccessKey = (response or {}).SecretAccessKey or "secret",
+                    Token = (response or {}).Token or "token",
+                    Expiration = (response or {}).Expiration or "2030-01-01T20:00:00Z",
+                  }
+                end,
+              }
+          elseif opts.path == "/latest/api/token" and opts.method == "PUT" then
+            return {
+                status = 400,
+                read_body = function() return "fake" end,
+            }
+          else
+            error("bad test path provided??? " .. tostring(opts.path))
+          end
+        end,
+      }
+    end,
+  }
 
   local EC2MetadataCredentials
 

--- a/src/resty/aws/credentials/EC2MetadataCredentials.lua
+++ b/src/resty/aws/credentials/EC2MetadataCredentials.lua
@@ -141,10 +141,18 @@ function EC2MetadataCredentials:refresh()
                 " " .. tostring(iam_security_token_request:read_body())
   end
 
-  local iam_security_token_data = json.decode(iam_security_token_request:read_body())
+  local iam_security_token_request_body = iam_security_token_request:read_body()
+  local iam_security_token_data = json.decode(iam_security_token_request_body)
+
+  if not iam_security_token_data.AccessKeyId then
+    return nil, "Unable to request EC2 IAM credentials for role " .. iam_role_name ..
+                " Request returned unexpected result " .. iam_security_token_request_body
+  end
 
   log(DEBUG, "Received temporary IAM credential from EC2 metadata service for role '",
-                     iam_role_name, "' with session token: ", iam_security_token_data.Token)
+              iam_role_name, "' with session token: ",
+              string.sub(iam_security_token_data.Token, 1 , 10),
+              "...")
 
   self:set(iam_security_token_data.AccessKeyId,
            iam_security_token_data.SecretAccessKey,


### PR DESCRIPTION
## Summary

This PR adds support for using IMDSv2 service in EC2 metadata credential provider. Manually tested with IMDSv2 optional and IMDSv2 required.

FTI-5232

This PR also adds more error handling into EC2 metadata credential provider. Ref: https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_iam-ec2.html (see the section `The iam/security-credentials/[role-name] document indicates "Code":"AssumeRoleUnauthorizedAccess"`)

FTI-5232