### PR TITLE
chore(*): support SDK_VERSION_TAG env var and fetch latest tag in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,8 @@ jobs:
 
     - name: Run tests
       run: |
+        # Fetch latest aws-sdk-js release tag
+        export SDK_VERSION_TAG=$(curl -s https://api.github.com/repos/aws/aws-sdk-js/tags | jq '.[0].name')
         make dev
         /usr/local/openresty/luajit/bin/luarocks make
         busted

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -6,7 +6,7 @@
 # It will convert the service descriptions of the specified SDK version
 # (see SDK_VERSION_TAG) into Lua modules and generate a rockspec.
 
-SDK_VERSION_TAG=v2.751.0
+SDK_VERSION_TAG="${SDK_VERSION_TAG:-v2.1434.0}"
 
 # ----------- nothing to customize below -----------
 TARGET=./src/resty/aws/raw-api
@@ -20,7 +20,7 @@ if [ -d $SOURCE ]; then
   echo "directory $SOURCE already exists, delete before updating"
   exit 1
 fi
-git clone --branch=$SDK_VERSION_TAG --depth=1 https://github.com/aws/aws-sdk-js.git $SOURCE
+git clone --branch="$SDK_VERSION_TAG" --depth=1 https://github.com/aws/aws-sdk-js.git $SOURCE
 
 
 # get a list of API files


### PR DESCRIPTION
## Summary

This PR adds support for using `SDK_VERSION_TAG` environment variable to run `update_api`, and let CI use latest `aws-sdk-js` release tag for testing.

Fix #56 