### PR TITLE
fix(*): fix v4 signing request should correctly canonicalized query table as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+### Unreleased
+
+- fix: fix v4 signing request should correctly canonicalized query table as well
+  [76](https://github.com/Kong/lua-resty-aws/pull/76)
+
 ### 1.3.0 (15-Aug-2023)
 
 - fix: fix AWS_CONTAINER_CREDENTIALS_FULL_URI parsing.

--- a/src/resty/aws/request/signatures/utils.lua
+++ b/src/resty/aws/request/signatures/utils.lua
@@ -73,6 +73,8 @@ local function canonicalise_query_string(query)
 
   elseif type(query) == "table" then
     for key, val in pairs(query) do
+      key = ngx.unescape_uri(key):gsub("[^%w%-%._~]", percent_encode)
+      val = ngx.unescape_uri(val):gsub("[^%w%-%._~]", percent_encode)
       q[#q+1] = key .. "=" .. val
     end
 


### PR DESCRIPTION
## Summary

This PR ensures that `canonicalise_query_string` should always return a URL encoded format query string. Currently when `query` is a table, the value will not be encoded again. This makes the STS assumeRole not working since assumeRole requires a IAM ARN which contains colon that should be URL encoded. Calling STS assumeRole will return signature not match error without the PR's fix.