### PR TITLE
fix(*): lazily initialize structures to avoid c-boundary errors on require

### DIFF
--- a/src/resty/aws/credentials/CredentialProviderChain.lua
+++ b/src/resty/aws/credentials/CredentialProviderChain.lua
@@ -11,7 +11,10 @@ CredentialProviderChain.__index = CredentialProviderChain
 local aws_config = require("resty.aws.config")
 
 
-CredentialProviderChain.defaultProviders = {} do
+CredentialProviderChain.defaultProviders = {}
+
+
+local function initialize()
   -- while not everything is implemented this will load what we do have without
   -- failing on what is missing. Will auto pick up newly added classes afterwards.
   local function add_if_exists(name, opts)
@@ -41,6 +44,8 @@ CredentialProviderChain.defaultProviders = {} do
   else
     add_if_exists("EC2MetadataCredentials")
   end
+
+  initialize = nil
 end
 
 --- Constructor, inherits from `Credentials`.
@@ -65,6 +70,10 @@ end
 -- @param opt options table, additional fields to the `Credentials` class:
 -- @param opt.providers array of `Credentials` objects or functions (functions must return a `Credentials` object)
 function CredentialProviderChain:new(opts)
+  if initialize then
+    initialize()
+  end
+
   local self = Super:new(opts)  -- override 'self' to be the new object/class
   setmetatable(self, CredentialProviderChain)
 

--- a/src/resty/aws/credentials/RemoteCredentials.lua
+++ b/src/resty/aws/credentials/RemoteCredentials.lua
@@ -15,9 +15,11 @@ local http = require "resty.luasocket.http"
 local json = require "cjson"
 
 
-local FullUri do
-  -- construct the URL
+local FullUri
 
+
+local function initialize()
+  -- construct the URL
   local function makeset(t)
     for i = 1, #t do
       t[t[i]] = true
@@ -73,8 +75,9 @@ local FullUri do
     FullUri.port = FullUri.port or
                     ({ http = 80, https = 443 })[FullUri.scheme]
   end
-end
 
+  initialize = nil
+end
 
 
 -- Create class
@@ -96,6 +99,10 @@ end
 -- updates credentials.
 -- @return success, or nil+err
 function RemoteCredentials:refresh()
+  if initialize then
+    initialize()
+  end
+
   if not FullUri then
     return nil, "No URI environment variables found for RemoteCredentials"
   end

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -15,7 +15,7 @@ local tablex = require("pl.tablex")
 local lookup_helper = function(self, key)  -- signature to match __index meta-method
   if type(key) == "string" then
     local lckey = key:lower()
-    for k,v in pairs(self) do
+    for k in pairs(self) do
       if type(k) == "string" and k:lower() == lckey then
         error(("key '%s' not found, did you mean '%s'?"):format(key, k), 2)
       end
@@ -193,7 +193,7 @@ do
   -- @param service service-instance being created; field `aws` is the aws instance,
   -- `config` is the service instance config, `api` the service api.
   function AWS.configureEndpoint(service)
-    for i, key in ipairs(derivedKeys(service)) do
+    for _, key in ipairs(derivedKeys(service)) do
 
       local region_rule_config = aws_config.region.rules[key]  --> contains regions templates
       if type(region_rule_config) == 'string' then

--- a/src/resty/aws/request/validate.lua
+++ b/src/resty/aws/request/validate.lua
@@ -441,7 +441,7 @@ local validators do
   local list_checks do
     local function get_length(t)  -- gets length of an array (with holes)
       local size = 0
-      for k,v in pairs(t) do
+      for k in pairs(t) do
         if type(k) ~= "number" then
           return nil, "list contains non-numeric indices"
         end


### PR DESCRIPTION
### Summary

Moves the code that was previously running on `module` level to `initialize` function that are lazily called when needed. This is to avoid the `yield accross C-boundary` errors during `require`.