### PR TITLE
fix pl.path can't resolve the path started with ~

### DIFF
--- a/spec/03-credentials/08-SharedFileCredentials_spec.lua
+++ b/spec/03-credentials/08-SharedFileCredentials_spec.lua
@@ -8,11 +8,11 @@ local origin_read = pl_config.read
 local origin_isfile = pl_path.isfile
 
 pl_config.read = function(name, ...)
-  return hooked_file[name] or origin_read(name, ...)
+  return hooked_file[pl_path.expanduser(name)] or origin_read(name, ...)
 end
 
 pl_path.isfile = function(name)
-  return hooked_file[name] and true or origin_isfile(name)
+  return hooked_file[pl_path.expanduser(name)] and true or origin_isfile(name)
 end
 
 local function hook_config_file(name, content)
@@ -40,7 +40,7 @@ describe("SharedFileCredentials_spec", function()
   end)
 
   it("gets from config", function()
-    hook_config_file("~/.aws/config", {
+    hook_config_file(pl_path.expanduser("~/.aws/config"), {
       default = {
         aws_access_key_id = "access",
         aws_secret_access_key = "secret",
@@ -58,7 +58,7 @@ describe("SharedFileCredentials_spec", function()
   end)
 
   it("gets from credentials", function()
-    hook_config_file("~/.aws/credentials", {
+    hook_config_file(pl_path.expanduser("~/.aws/credentials"), {
       default = {
         aws_access_key_id = "access",
         aws_secret_access_key = "secret",

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -169,7 +169,7 @@ do
   -- returns an empty table if the section does not exist
   local function load_file(filename, section)
     assert(type(filename) == "string", "expected filename to be a string")
-    if not pl_path.isfile(filename) then
+    if not pl_path.isfile(pl_path.expanduser(filename)) then
       return nil, "not a file: '"..filename.."'"
     end
 
@@ -228,7 +228,7 @@ end
 -- table if the config file does not exist.
 -- @return options table as gotten from the configuration file, or nil+err.
 function config.load_config()
-  if not pl_path.isfile(env_vars.AWS_CONFIG_FILE.value) then
+  if not pl_path.isfile(pl_path.expanduser(env_vars.AWS_CONFIG_FILE.value)) then
     -- file doesn't exist
     return {}
   end
@@ -243,7 +243,7 @@ end
 -- @return credentials table as gotten from the credentials file, or a table
 -- with the key, id, and token from the configuration file, table can be empty.
 function config.load_credentials()
-  if pl_path.isfile(env_vars.AWS_SHARED_CREDENTIALS_FILE.value) then
+  if pl_path.isfile(pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)) then
     local creds = config.load_credentials_file(env_vars.AWS_SHARED_CREDENTIALS_FILE.value, env_vars.AWS_PROFILE.value)
     if creds then -- ignore error, already logged
       return creds
@@ -279,7 +279,7 @@ end
 function config.get_config()
   local cfg = config.load_config() or {}   -- ignore error, already logged
 
-  if pl_path.isfile(env_vars.AWS_SHARED_CREDENTIALS_FILE.value) then
+  if pl_path.isfile(pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)) then
     -- there is a creds file, so override creds with creds file
     local creds = config.load_credentials_file(
       env_vars.AWS_SHARED_CREDENTIALS_FILE.value, env_vars.AWS_PROFILE.value)  -- ignore error, already logged


### PR DESCRIPTION
Base on https://github.com/lunarmodules/luafilesystem/issues/172, seem `pl.isfile` and `pl.isdif` will return the wrong result if the path start with "~"

currently I can confirm there's a bug when load cred file:

```
local credential = require("resty.aws.config").load_credentials_file("~/.aws/credentials", "xxxprofile")
```

Above I got nil caused by [here](https://github.com/Kong/lua-resty-aws/blob/main/src/resty/aws/config.lua#L172-L173), however, I am sure my credentials file exist and format is definitely correct. So I raised the https://github.com/lunarmodules/luafilesystem/issues/172 issue. Not sure how and when they fix it but we can safely fix this issue by an absolute path.