### PR TITLE
fix(validate): unsupport fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,11 @@ Release process:
 1. test installing the rock from LuaRocks
 
 
+### Unreleased
+
+- fix: validator failure for some of the field types
+  [95](https://github.com/Kong/lua-resty-aws/pull/95)
+
 ### 1.3.5 (19-Sep-2023)
 
 - fix: lazily initialize structures to avoid c-boundary errors on require

--- a/src/resty/aws/request/validate.lua
+++ b/src/resty/aws/request/validate.lua
@@ -435,6 +435,8 @@ local validators do
     type = always_pass,
     deprecated = always_pass,
     box = always_pass,
+    locationName = always_pass,
+    location = always_pass,
   },ops_mt)
 
 
@@ -491,6 +493,7 @@ local validators do
       locationName = always_pass,
       sensitive = always_pass,
       box = always_pass,
+      flattened = always_pass,
     },ops_mt)
   end
 
@@ -566,6 +569,9 @@ local validators do
     deprecatedMessage = always_pass,
     deprecated = always_pass,
     sensitive = always_pass,
+    locationName = always_pass,
+    location = always_pass,
+    xmlNamespace = always_pass,
   },ops_mt)
 
 


### PR DESCRIPTION
APIs listed below is unavailable due to unsupported filed for the validator.
listObjectsV2
getBucketLifecycleConfiguration
putBucketLifecycleConfiguration