### PR TITLE
chore(*): remove sample access key from SDK documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Release process:
   [100](https://github.com/Kong/lua-resty-aws/pull/100)
 - security: remove the documentation entry that contains a sample access key from AWS SDK. This
   avoids false postive vulnerability report.
+  [102](https://github.com/Kong/lua-resty-aws/pull/102)
 
 ### 1.3.6 (25-Dec-2023)
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Release process:
   [94](https://github.com/Kong/lua-resty-aws/pull/94)
 - fix: fix the bug of missing boolean type with a value of false in the generated request body
   [100](https://github.com/Kong/lua-resty-aws/pull/100)
+- security: remove the documentation entry that contains a sample access key from AWS SDK. This
+  avoids false postive vulnerability report.
 
 ### 1.3.6 (25-Dec-2023)
 

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -11,7 +11,7 @@ SDK_VERSION_TAG=v2.751.0
 # ----------- nothing to customize below -----------
 TARGET=./src/resty/aws/raw-api
 SOURCE=./delete-me
-TFILE=$(mktemp -t tmpXXX)
+TFILE=$(mktemp)
 set -e
 pushd "$(dirname "$(realpath "$0")")" > /dev/null
 

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -75,8 +75,6 @@ echo "]===]))" >> "$FILENAME"
 # Copy the individual API files
 for f in "${file_list[@]}"; do
   source_file=$SOURCE/apis/$f.normal.json
-  ls -l "$source_file"
-  ls -l "$TFILE"
   jq 'walk( if (type == "object") and has("documentation") and (.documentation|contains("wJalrXUtnFEMI")) then del(.documentation) else . end )' "$source_file" >| "$TFILE"
   mv -f "$TFILE" "$source_file"; touch "$TFILE"
   # replace . with - since . can't be in a Lua module name

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -75,6 +75,8 @@ echo "]===]))" >> "$FILENAME"
 # Copy the individual API files
 for f in "${file_list[@]}"; do
   source_file=$SOURCE/apis/$f.normal.json
+  ls -l "$source_file"
+  ls -l "$TFILE"
   jq 'walk( if (type == "object") and has("documentation") and (.documentation|contains("wJalrXUtnFEMI")) then del(.documentation) else . end )' "$source_file" >| "$TFILE"
   mv -f "$TFILE" "$source_file"
   # replace . with - since . can't be in a Lua module name

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -78,7 +78,7 @@ for f in "${file_list[@]}"; do
   ls -l "$source_file"
   ls -l "$TFILE"
   jq 'walk( if (type == "object") and has("documentation") and (.documentation|contains("wJalrXUtnFEMI")) then del(.documentation) else . end )' "$source_file" >| "$TFILE"
-  mv -f "$TFILE" "$source_file"
+  mv -f "$TFILE" "$source_file"; touch "$TFILE"
   # replace . with - since . can't be in a Lua module name
   target_file=$TARGET/${f//./-}.lua
   echo "adding: $target_file"

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -75,6 +75,7 @@ echo "]===]))" >> "$FILENAME"
 # Copy the individual API files
 for f in "${file_list[@]}"; do
   source_file=$SOURCE/apis/$f.normal.json
+  # remove example keys from documentation to prevent security reports from being triggered
   jq 'walk( if (type == "object") and has("documentation") and (.documentation|contains("wJalrXUtnFEMI")) then del(.documentation) else . end )' "$source_file" >| "$TFILE"
   mv -f "$TFILE" "$source_file"; touch "$TFILE"
   # replace . with - since . can't be in a Lua module name

--- a/update_api_files.sh
+++ b/update_api_files.sh
@@ -11,6 +11,7 @@ SDK_VERSION_TAG=v2.751.0
 # ----------- nothing to customize below -----------
 TARGET=./src/resty/aws/raw-api
 SOURCE=./delete-me
+TFILE=$(mktemp -t tmpXXX)
 set -e
 pushd "$(dirname "$(realpath "$0")")" > /dev/null
 
@@ -74,6 +75,8 @@ echo "]===]))" >> "$FILENAME"
 # Copy the individual API files
 for f in "${file_list[@]}"; do
   source_file=$SOURCE/apis/$f.normal.json
+  jq 'walk( if (type == "object") and has("documentation") and (.documentation|contains("wJalrXUtnFEMI")) then del(.documentation) else . end )' "$source_file" >| "$TFILE"
+  mv -f "$TFILE" "$source_file"
   # replace . with - since . can't be in a Lua module name
   target_file=$TARGET/${f//./-}.lua
   echo "adding: $target_file"


### PR DESCRIPTION
In the AWS SDK, there is sample access key sample `wJalrXUtnFEMI` that may trigger CVE report. This PR tries to remove it.

This is a dangerous operation! Before merge, we must ensure only the access key sample is removed!

FTI-5732 FTI-5732