### PR TITLE
feat: container credential provider support auth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ Release process:
 - security: remove the documentation entry that contains a sample access key from AWS SDK. This
   avoids false postive vulnerability report.
   [102](https://github.com/Kong/lua-resty-aws/pull/102)
+- feat: container credential provider now supports using auth token defined in
+  AWS_CONTAINER_AUTHORIZATION_TOKEN and AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE.
+  [107](https://github.com/Kong/lua-resty-aws/pull/107)
 
 ### 1.3.6 (25-Dec-2023)
 

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -147,14 +147,8 @@ local env_vars = {
   -- if both are set, the value in AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE will be used
   --
   -- This is also used by EKS Pod Identity authorization
+  AWS_CONTAINER_AUTHORIZATION_TOKEN = { name = "AWS_CONTAINER_AUTHORIZATION_TOKEN", default = nil },
   AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = { name = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", default = nil },
-  -- TODO: ---
-  -- A possible issue is that due to Nginx worker process's envvars isolation
-  -- the AWS_CONTAINER_AUTHORIZATION_TOKEN may not get refreshed.
-  -- According to the AWS documentation, the AWS_CONTAINER_AUTHORIZATION_TOKEN is only
-  -- used in IoT product Greengrass, which is not a common use case.
-  -- AWS_CONTAINER_AUTHORIZATION_TOKEN = { name = "AWS_CONTAINER_AUTHORIZATION_TOKEN", default = nil },
-  -- ---------
 
   -- HTTP/HTTPs proxy settings
   HTTP_PROXY = { name = "http_proxy", default = nil },

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -57,6 +57,8 @@
 -- * `AMAZON_SESSION_TOKEN`
 -- * `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`
 -- * `AWS_CONTAINER_CREDENTIALS_FULL_URI`
+-- * `AWS_CONTAINER_AUTHORIZATION_TOKEN`
+-- * `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`
 
 
 local pl_path = require "pl.path"
@@ -140,6 +142,19 @@ local env_vars = {
   -- Variables used in RemoteCredentials (and in the CredentialProviderChain)
   AWS_CONTAINER_CREDENTIALS_RELATIVE_URI = { name = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", default = nil },
   AWS_CONTAINER_CREDENTIALS_FULL_URI = { name = "AWS_CONTAINER_CREDENTIALS_FULL_URI", default = nil },
+  -- Token related Variables used in RemoteCredentials
+  -- Note that AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE has higher priority than AWS_CONTAINER_AUTHORIZATION_TOKEN
+  -- if both are set, the value in AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE will be used
+  --
+  -- This is also used by EKS Pod Identity authorization
+  AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE = { name = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", default = nil },
+  -- TODO: ---
+  -- A possible issue is that due to Nginx worker process's envvars isolation
+  -- the AWS_CONTAINER_AUTHORIZATION_TOKEN may not get refreshed.
+  -- According to the AWS documentation, the AWS_CONTAINER_AUTHORIZATION_TOKEN is only
+  -- used in IoT product Greengrass, which is not a common use case.
+  -- AWS_CONTAINER_AUTHORIZATION_TOKEN = { name = "AWS_CONTAINER_AUTHORIZATION_TOKEN", default = nil },
+  -- ---------
 
   -- HTTP/HTTPs proxy settings
   HTTP_PROXY = { name = "http_proxy", default = nil },

--- a/src/resty/aws/credentials/RemoteCredentials.lua
+++ b/src/resty/aws/credentials/RemoteCredentials.lua
@@ -79,15 +79,9 @@ local function initialize()
                     ({ http = 80, https = 443 })[FullUri.scheme]
   end
 
-  -- get auth token
-  if aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN then
-    AuthToken = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN
-  end
-
-  -- get auth token file path
-  if aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE then
-    AuthTokenFile = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
-  end
+  -- get auth token/file
+  AuthToken = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN
+  AuthTokenFile = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
 
   initialize = nil
 end

--- a/src/resty/aws/credentials/RemoteCredentials.lua
+++ b/src/resty/aws/credentials/RemoteCredentials.lua
@@ -17,6 +17,7 @@ local readfile = require("pl.utils").readfile
 
 
 local FullUri
+local AuthToken
 local AuthTokenFile
 
 
@@ -78,6 +79,11 @@ local function initialize()
                     ({ http = 80, https = 443 })[FullUri.scheme]
   end
 
+  -- get auth token
+  if aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN then
+    AuthToken = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN
+  end
+
   -- get auth token file path
   if aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE then
     AuthTokenFile = aws_config.global.AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
@@ -116,6 +122,11 @@ function RemoteCredentials:refresh()
 
 
   local headers = {}
+
+  if AuthToken then
+    headers["Authorization"] = AuthToken
+  end
+
   if AuthTokenFile then
     local token, err = readfile(AuthTokenFile)
     if not token then

--- a/src/resty/aws/credentials/RemoteCredentials.lua
+++ b/src/resty/aws/credentials/RemoteCredentials.lua
@@ -33,7 +33,7 @@ local function initialize()
 
   local FULL_URI_UNRESTRICTED_PROTOCOLS = makeset { "https" }
   local FULL_URI_ALLOWED_PROTOCOLS = makeset { "http", "https" }
-  local FULL_URI_ALLOWED_HOSTNAMES = makeset { "localhost", "127.0.0.1" }
+  local FULL_URI_ALLOWED_HOSTNAMES = makeset { "localhost", "127.0.0.1", "169.254.170.23" }
   local RELATIVE_URI_HOST = '169.254.170.2'
 
   local function getFullUri()


### PR DESCRIPTION
## Summary

This PR adds support for using authorization token in Container Credential Provider. Container Credential Provider uses two environment variables for the auth token content: `AWS_CONTAINER_AUTHORIZATION_TOKEN`(for token value)  and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`(for a file path that stores token value). See https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html. If one of the token env vars exists, the token value will be used as `Authorization` header value when requesting credential provider URI.

By adding support for auth token in Container Credential Provider, we can support the latest "Pod Identity" IAM Auth method in AWS EKS. See [How EKS Pod Identity works](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html)

Reference:
https://github.com/aws/aws-sdk-js/blob/3276faf83e32dfea637797c66a73431affe54e64/lib/credentials/remote_credentials.js#L118C3-L118C18

https://konghq.atlassian.net/browse/KAG-3424