### PR TITLE
fix(*): patch expanduser to be more friendly to OpenResty environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+
+### Unreleased
+
+- fix: patch expanduser function to be more friendly to OpenResty environment
+  [111](https://github.com/Kong/lua-resty-aws/pull/111)
+
 ### 1.4.0 (20-Mar-2024)
 
 - fix: aws configuration cannot be loaded due to pl.path cannot resolve the path started with ~

--- a/spec/01-generic/01-config_spec.lua
+++ b/spec/01-generic/01-config_spec.lua
@@ -19,6 +19,7 @@ describe("config loader", function()
   local config
   before_each(function()
     restore()
+    restore.setenv("HOME")
     pl_utils.writefile(config_filename, config_info)
   end)
 

--- a/spec/03-credentials/08-SharedFileCredentials_spec.lua
+++ b/spec/03-credentials/08-SharedFileCredentials_spec.lua
@@ -1,6 +1,7 @@
 local pl_path = require "pl.path"
 local pl_config = require "pl.config"
 local tbl_clear = require "table.clear"
+local restore = require "spec.helpers"
 
 local hooked_file = {}
 
@@ -24,12 +25,15 @@ describe("SharedFileCredentials_spec", function()
   local SharedFileCredentials_spec
 
   before_each(function()
+    -- make ci happy
+    restore.setenv("HOME", "/home/ci-test")
     local _ = require("resty.aws.config").global -- load config before anything else
 
     SharedFileCredentials_spec = require "resty.aws.credentials.SharedFileCredentials"
   end)
 
   after_each(function()
+    restore()
     tbl_clear(hooked_file)
   end)
 

--- a/spec/03-credentials/08-SharedFileCredentials_spec.lua
+++ b/spec/03-credentials/08-SharedFileCredentials_spec.lua
@@ -9,11 +9,11 @@ local origin_read = pl_config.read
 local origin_isfile = pl_path.isfile
 
 pl_config.read = function(name, ...)
-  return hooked_file[pl_path.expanduser(name)] or origin_read(name, ...)
+  return hooked_file[name] or origin_read(name, ...)
 end
 
 pl_path.isfile = function(name)
-  return hooked_file[pl_path.expanduser(name)] and true or origin_isfile(name)
+  return hooked_file[name] and true or origin_isfile(name)
 end
 
 local function hook_config_file(name, content)

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -220,10 +220,10 @@ local function expanduser(P)
 
   if (not home) then
       -- try alternatives on Windows
-      home = getenv 'USERPROFILE'
+      home = getenv('USERPROFILE')
       if not home then
-          local hd = getenv 'HOMEDRIVE'
-          local hp = getenv 'HOMEPATH'
+          local hd = getenv('HOMEDRIVE')
+          local hp = getenv('HOMEPATH')
           if not (hd and hp) then
             return nil, "failed to expand '~' (HOME, USERPROFILE, and HOMEDRIVE and/or HOMEPATH not set)"
           end
@@ -240,18 +240,18 @@ do
   local function load_file(filename, section)
     assert(type(filename) == "string", "expected filename to be a string")
 
-    local expanded_path, err = expanduser(filename)
-    if not expanded_path then
+    local expanded_filename, err = expanduser(filename)
+    if not expanded_filename then
       return nil, "failed expanding path '"..filename.."': "..tostring(err)
     end
 
-    if not pl_path.isfile(expanded_path) then
+    if not pl_path.isfile(expanded_filename) then
       return nil, "not a file: '"..filename.."'"
     end
 
-    local contents, err = pl_config.read(filename, { variabilize = false })
+    local contents, err = pl_config.read(expanded_filename, { variabilize = false })
     if not contents then
-      return nil, "failed reading file '"..filename.."': "..tostring(err)
+      return nil, "failed reading file '"..filename.."'(expanded: '"..expanded_filename.."'): "..tostring(err)
     end
 
     if not section then
@@ -260,11 +260,11 @@ do
 
     assert(type(section) == "string", "expected section to be a string or falsy")
     if not contents[section] then
-      ngx.log(ngx.DEBUG, "section '",section,"' does not exist in file '",filename,"'")
+      ngx.log(ngx.DEBUG, "section '",section,"' does not exist in file '",filename,"'(expanded: '"..expanded_filename.."')")
       return {}
     end
 
-    ngx.log(ngx.DEBUG, "loaded section '",section,"' from file '",filename,"'")
+    ngx.log(ngx.DEBUG, "loaded section '",section,"' from file '",filename,"'(expanded: '"..expanded_filename.."')")
     return contents[section]
   end
 

--- a/src/resty/aws/config.lua
+++ b/src/resty/aws/config.lua
@@ -178,7 +178,13 @@ do
   -- returns an empty table if the section does not exist
   local function load_file(filename, section)
     assert(type(filename) == "string", "expected filename to be a string")
-    if not pl_path.isfile(pl_path.expanduser(filename)) then
+
+    local expanded_path, err = pl_path.expanduser(filename)
+    if not expanded_path then
+      return nil, "failed expanding path '"..filename.."': "..tostring(err)
+    end
+
+    if not pl_path.isfile(expanded_path) then
       return nil, "not a file: '"..filename.."'"
     end
 
@@ -237,7 +243,8 @@ end
 -- table if the config file does not exist.
 -- @return options table as gotten from the configuration file, or nil+err.
 function config.load_config()
-  if not pl_path.isfile(pl_path.expanduser(env_vars.AWS_CONFIG_FILE.value)) then
+  local expanded_path = pl_path.expanduser(env_vars.AWS_CONFIG_FILE.value)
+  if not (expanded_path and pl_path.isfile(expanded_path)) then
     -- file doesn't exist
     return {}
   end
@@ -252,7 +259,8 @@ end
 -- @return credentials table as gotten from the credentials file, or a table
 -- with the key, id, and token from the configuration file, table can be empty.
 function config.load_credentials()
-  if pl_path.isfile(pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)) then
+  local expanded_path = pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)
+  if expanded_path and pl_path.isfile(expanded_path) then
     local creds = config.load_credentials_file(env_vars.AWS_SHARED_CREDENTIALS_FILE.value, env_vars.AWS_PROFILE.value)
     if creds then -- ignore error, already logged
       return creds
@@ -288,7 +296,8 @@ end
 function config.get_config()
   local cfg = config.load_config() or {}   -- ignore error, already logged
 
-  if pl_path.isfile(pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)) then
+  local expanded_path = pl_path.expanduser(env_vars.AWS_SHARED_CREDENTIALS_FILE.value)
+  if expanded_path and pl_path.isfile(expanded_path) then
     -- there is a creds file, so override creds with creds file
     local creds = config.load_credentials_file(
       env_vars.AWS_SHARED_CREDENTIALS_FILE.value, env_vars.AWS_PROFILE.value)  -- ignore error, already logged


### PR DESCRIPTION
## Summary 

`pl.path.expanduser` may return with `nil, err` when received a path argument starting with `~` but `$HOME`(or other home path related) environment variable is not present. This PR adds proper error handling code when calling `expanduser`.