### PR TITLE
fix(sts): do not inject region info for STS service with VPC endpoint hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Release process:
 - feat: decode AWS api response json body with array metatable
   [114](https://github.com/Kong/lua-resty-aws/pull/114)
 
+- fix: do not inject region info for sts service with VPC endpoint hostname
+  [113](https://github.com/Kong/lua-resty-aws/pull/113)
 
 ### 1.4.1 (19-Apr-2024)
 

--- a/spec/01-generic/02-aws_spec.lua
+++ b/spec/01-generic/02-aws_spec.lua
@@ -92,4 +92,37 @@ describe("AWS main instance", function()
     assert.same("https://sts.eu-central-1.amazonaws.com", sts.config.endpoint)
   end)
 
+  it("do not inject sts region info for sts vpc endpoint url", function()
+    local aws = AWS({
+      region = "eu-central-1",
+      stsRegionalEndpoints = "regional",
+    })
+
+    aws.config.credentials = aws:Credentials {
+      accessKeyId = "test_id",
+      secretAccessKey = "test_key",
+    }
+
+    assert.is.table(aws.config)
+
+    local regional_vpc_endpoint_url = "https://vpce-abcdefg-hijklmn-eu-central-1a.sts.eu-central-1.vpce.amazonaws.com"
+
+    local sts, _ = aws:STS({
+      endpoint = regional_vpc_endpoint_url,
+    })
+    local _, _ = sts:assumeRole {
+      RoleArn = "aws:arn::XXXXXXXXXXXXXXXXX:test123",
+      RoleSessionName = "aws-test",
+    }
+
+    assert.same(regional_vpc_endpoint_url, sts.config.endpoint)
+
+    local _, _ = sts:assumeRole {
+      RoleArn = "aws:arn::XXXXXXXXXXXXXXXXX:test123",
+      RoleSessionName = "aws-test",
+    }
+    assert.same(regional_vpc_endpoint_url, sts.config.endpoint)
+  end)
+
+
 end)

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -323,7 +323,10 @@ local function generate_service_methods(service)
         -- https://github.com/aws/aws-sdk-js/blob/307e82673b48577fce4389e4ce03f95064e8fe0d/lib/services/sts.js#L78-L82
         assert(service.config.region, "region is required when using STS regional endpoints")
 
-        if not service.config._regionalEndpointInjected then
+        -- If the endpoint is a VPC endpoint DNS hostname then we don't need to inject the region
+        -- VPC endpoint DNS hostnames always contain region, see
+        -- https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html#interface-endpoint-dns-hostnames
+        if not service.config._regionalEndpointInjected and not service.config.endpoint:match("^(.+)(%.vpce%.amazonaws%.com)$") then
           local pre, post = service.config.endpoint:match("^(.+)(%.amazonaws%.com)$")
           service.config.endpoint = pre .. "." .. service.config.region .. post
           service.config.signingRegion = service.config.region

--- a/src/resty/aws/init.lua
+++ b/src/resty/aws/init.lua
@@ -8,6 +8,8 @@ local execute_request = require("resty.aws.request.execute")
 local split = require("pl.utils").split
 local tablex = require("pl.tablex")
 
+local AWS_PUBLIC_DOMAIN_PATTERN = "^(.+)(%.amazonaws%.com)$"
+local AWS_VPC_ENDPOINT_DOMAIN_PATTERN = "^(.+)(%.vpce%.amazonaws%.com)$"
 
 
 -- case-insensitive lookup help.
@@ -326,8 +328,8 @@ local function generate_service_methods(service)
         -- If the endpoint is a VPC endpoint DNS hostname then we don't need to inject the region
         -- VPC endpoint DNS hostnames always contain region, see
         -- https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html#interface-endpoint-dns-hostnames
-        if not service.config._regionalEndpointInjected and not service.config.endpoint:match("^(.+)(%.vpce%.amazonaws%.com)$") then
-          local pre, post = service.config.endpoint:match("^(.+)(%.amazonaws%.com)$")
+        if not service.config._regionalEndpointInjected and not service.config.endpoint:match(AWS_VPC_ENDPOINT_DOMAIN_PATTERN) then
+          local pre, post = service.config.endpoint:match(AWS_PUBLIC_DOMAIN_PATTERN)
           service.config.endpoint = pre .. "." .. service.config.region .. post
           service.config.signingRegion = service.config.region
           service.config._regionalEndpointInjected = true


### PR DESCRIPTION
## Summary

AWS services can be used inside a private VPC without Internet access by creating private links(VPC endpoints). When creating VPC endpoint for an AWS service, the `Enable private DNS name` is enabled by default, which means that a private DNS record will be created whose value is just the same as the AWS service's public endpoint(for example, `s3.amazonaws.com`) but pointing at the private VPC endpoint. This is what is expected to be a common practice when using VPC endpoint to access AWS service.

However, user can also disable it to not create this "fake" DNS record, and use the VPC endpoint hostname directly(something like `vpce-abcdefghijklmn-abcdefg.sts.us-east-1.vpce.amazonaws.com`). In this case, there is no need to inject region info into the endpoint domain since the hostname itself always contains the region for this VPC endpoint.

We've encountered a case in which the user is using a VPC endpoint hostname directly for STS service and region info gets injected unexpectedly, thus STS service cannot be used. This PR fixes it.


More information: https://docs.aws.amazon.com/vpc/latest/privatelink/privatelink-access-aws-services.html#interface-endpoint-dns-hostnames



## Issue

[FTI-5934](https://konghq.atlassian.net/browse/FTI-5934)


[FTI-5934]: https://konghq.atlassian.net/browse/FTI-5934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ