### PR TITLE
feat(*): decode api response json body with array metatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Release process:
 1. test installing the rock from LuaRocks
 
 
+### Unreleased
+
+- feat: decode AWS api response json body with array metatable
+  [114](https://github.com/Kong/lua-resty-aws/pull/114)
+
+
 ### 1.4.1 (19-Apr-2024)
 
 - fix: patch expanduser function to be more friendly to OpenResty environment

--- a/src/resty/aws/request/execute.lua
+++ b/src/resty/aws/request/execute.lua
@@ -1,5 +1,8 @@
 local http = require "resty.luasocket.http"
-local json_decode = require("cjson.safe").new().decode
+
+local json_safe = require("cjson.safe").new()
+json_safe.decode_array_with_array_mt(true)
+local json_decode = json_safe.decode
 
 -- TODO: retries and back-off: https://docs.aws.amazon.com/general/latest/gr/api-retries.html
 


### PR DESCRIPTION
## Summary

This PR enables `cjson.decode_array_with_array_mt(true)` in the request executes, so that further `encode` on the response body may be able to transform an empty array back to the correct array format in plain JSON text.

## Issue

FTI-5937
