### PR TITLE
fix(request): build request body by operation payload field

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Release process:
 1. test installing the rock from LuaRocks
 
 
+### Unreleased
+
+- fix: build the request body based on payload field
+  [126](https://github.com/Kong/lua-resty-aws/pull/126)
+
+
 ### 1.5.2 (29-Jul-2024)
 
 - fix: fix sts regional endpoint injection under several cases

--- a/src/resty/aws/request/build.lua
+++ b/src/resty/aws/request/build.lua
@@ -205,6 +205,21 @@ local function build_request(operation, config, params)
     request.query[k] = v
   end
 
+  local payload_member = operation.input and operation.input.payload
+  if payload_member and body_tbl[payload_member] then
+    local member_config = operation.input.members[payload_member]
+    if member_config.type == "structure" then
+      body_tbl = type(body_tbl[payload_member]) == "table" and body_tbl[payload_member] or body_tbl
+
+    elseif body_tbl[payload_member] then
+      request.body = body_tbl[payload_member]
+      if member_config.type == "binary" and member_config.streaming == true then
+        request.headers["Content-Type"] = "binary/octet-stream"
+      end
+      body_tbl[payload_member] = nil
+    end
+  end
+
   local table_empty = not next(body_tbl)
   -- already has a raw body, or no body at all
   if request.body then


### PR DESCRIPTION
### Summary

This is a follow-up fix for #120 . 

The PR modifies the request build again with the following changes: when the `payload` field is specified inside the input schema, the request body will be built based on the parameter that specified by the `payload` field.

This behavior imitates the behavior defined in `aws-sdk-js`: https://github.com/aws/aws-sdk-js/blob/02153340ce052614c5437fe46ab1f49bfd8483f7/lib/protocol/rest_json.js#L24-L41
as well as https://github.com/aws/aws-sdk-js/blob/02153340ce052614c5437fe46ab1f49bfd8483f7/lib/protocol/rest_xml.js#L10-L26

### Issues

This fixes the breaking change behavior found here: https://github.com/Kong/kong/pull/13433
FTI-6138

