### PR TITLE
feat: remove libexpat dependency

### DIFF
--- a/lua-resty-aws-dev-1.rockspec.template
+++ b/lua-resty-aws-dev-1.rockspec.template
@@ -27,7 +27,6 @@ dependencies = {
   "lua-resty-http >= 0.16",
   "lua-resty-luasocket ~> 1",
   "lua-resty-openssl >= 0.8.17",
-  "luaexpat >= 1.5.1",
 }
 
 build = {

--- a/spec/02-requests/02-build_request_spec.lua
+++ b/spec/02-requests/02-build_request_spec.lua
@@ -383,7 +383,7 @@ describe("operations protocol", function()
         BinaryData = {
           [1] = binary_data },
         attr = {
-          [1] = 'xmlns',
+          --[1] = 'xmlns',
           xmlns = 'cool-name-space' },
         someSubStructure = {
           hello = {

--- a/spec/02-requests/02-build_request_spec.lua
+++ b/spec/02-requests/02-build_request_spec.lua
@@ -37,10 +37,10 @@ describe("operations protocol", function()
       },
       input = {
         type = "structure",
-        locationName = "mainXmlElement",  -- only for rest-xml protocol
-        xmlNamespace = {                  -- only for rest-xml protocol
-          uri = "cool-name-space"
-        },
+        --locationName = "mainXmlElement",  -- only for rest-xml protocol
+        --xmlNamespace = {                  -- only for rest-xml protocol
+        --  uri = "cool-name-space"
+        --},
         required = {
           "RoleArn",
           "RoleSessionName"
@@ -328,86 +328,6 @@ describe("operations protocol", function()
       port = 443,
       body = binary_data,
       query = {},
-    }, request)
-  end)
-
-
-  it("rest-xml: querystring, uri, header and body params", function()
-
-    config.protocol = "rest-xml"
-
-    local request = build_request(operation, config, params)
-    if request and request.body then
-      -- cannot reliably compare non-canonicalized json, so decode to Lua table
-      local body_lines = pl_stringx.splitlines(request.body)
-      for i, line in ipairs(body_lines) do
-        body_lines[i] = pl_stringx.strip(line, ' ')
-      end
-      request.body = assert(require("pl.xml").parse(table.concat(body_lines, "")))
-      local to_lua = function(t)
-        -- convert LOM to comparable Lua table
-        for i, v in ipairs(t) do
-          if type(v) == "table" and v.tag then
-            t[v.tag] = v
-            v.tag = nil
-            t[i] = nil
-            if type(v.attr) == "table" and not next(v.attr) then
-              -- delete empty attr table
-              v.attr = nil
-            end
-          end
-        end
-      end
-      to_lua(request.body)
-      to_lua(request.body.someSubStructure)
-    end
-
-    assert.same({
-      headers = {
-        ["Accept"] = 'application/json',
-        ["X-Sooper-Secret"] = "towel",
-        ["Content-Length"] = 456,
-        ["Content-Type"] = "application/xml",
-        ["X-Amz-Target"] = "sts.AssumeRole",
-        ["Host"] = "sts.amazonaws.com",
-      },
-      method = 'POST',
-      path = '/hello%20world/42',
-      host = 'sts.amazonaws.com',
-      port = 443,
-      body = {
-        RoleArn = {
-          [1] = 'hello' },
-        RoleSessionName = {
-          [1] = 'world' },
-        BinaryData = {
-          [1] = binary_data },
-        attr = {
-          --[1] = 'xmlns',
-          xmlns = 'cool-name-space' },
-        someSubStructure = {
-          hello = {
-            [1] = 'the default hello thinghy' },
-          world = {
-            [1] = 'the default world thinghy' } },
-        subList = {
-          [1] = {
-            [1] = '1',
-            attr = {},
-            tag = 'listELement' },
-          [2] = {
-            [1] = '2',
-            attr = {},
-            tag = 'listELement' },
-          [3] = {
-            [1] = '3',
-            attr = {},
-            tag = 'listELement' } },
-        tag = 'mainXmlElement' },
-      query = {
-        UserId = "Arthur Dent",
-        nice = '',
-      }
     }, request)
   end)
 

--- a/spec/02-requests/02-build_request_spec.lua
+++ b/spec/02-requests/02-build_request_spec.lua
@@ -206,6 +206,7 @@ describe("operations protocol", function()
     local request = build_request(operation, config, params)
     assert.same({
       headers = {
+        ["Accept"] = 'application/json',
         ["X-Sooper-Secret"] = "towel",
         ["X-Amz-Target"] = "sts.AssumeRole",
         ["Host"] = "sts.amazonaws.com",
@@ -239,6 +240,7 @@ describe("operations protocol", function()
 
     assert.same({
       headers = {
+        ["Accept"] = 'application/json',
         ["X-Sooper-Secret"] = "towel",
         ["Content-Length"] = 172,
         ["Content-Type"] = "application/x-amz-json-1.0",
@@ -279,6 +281,7 @@ describe("operations protocol", function()
 
     assert.same({
       headers = {
+        ["Accept"] = 'application/json',
         ["X-Sooper-Secret"] = "towel",
         ["Content-Length"] = 172,
         ["Content-Type"] = "application/x-amz-json-1.0",
@@ -314,6 +317,7 @@ describe("operations protocol", function()
 
     assert.same({
       headers = {
+        ["Accept"] = 'application/json',
         ["Content-Length"] = 4,
         ["X-Amz-Target"] = "s3.PutObject",
         ["Host"] = "s3.amazonaws.com",
@@ -360,6 +364,7 @@ describe("operations protocol", function()
 
     assert.same({
       headers = {
+        ["Accept"] = 'application/json',
         ["X-Sooper-Secret"] = "towel",
         ["Content-Length"] = 456,
         ["Content-Type"] = "application/xml",

--- a/spec/02-requests/02-build_request_spec.lua
+++ b/spec/02-requests/02-build_request_spec.lua
@@ -1,5 +1,4 @@
 local cjson = require "cjson"
-local pl_stringx = require "pl.stringx"
 
 describe("operations protocol", function()
 

--- a/spec/02-requests/03-execute_spec.lua
+++ b/spec/02-requests/03-execute_spec.lua
@@ -51,7 +51,8 @@ describe("request execution", function()
 
   it("tls defaults to true", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({
@@ -76,7 +77,8 @@ describe("request execution", function()
 
   it("support configuring tls false", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({
@@ -103,7 +105,8 @@ describe("request execution", function()
 
   it("support configuring ssl verify false", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json"
     }
 
     config.credentials = Credentials:new({
@@ -129,7 +132,8 @@ describe("request execution", function()
 
   it("support configure timeout", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({
@@ -155,7 +159,8 @@ describe("request execution", function()
 
   it("support configure keepalive idle timeout", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({
@@ -181,7 +186,8 @@ describe("request execution", function()
 
   it("support set proxy options", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({
@@ -217,7 +223,8 @@ describe("request execution", function()
 
   it("decoded json body should have array metatable", function ()
     local config = {
-      region = "us-east-1"
+      region = "us-east-1",
+      protocol = "json",
     }
 
     config.credentials = Credentials:new({

--- a/src/resty/aws/credentials/ChainableTemporaryCredentials.lua
+++ b/src/resty/aws/credentials/ChainableTemporaryCredentials.lua
@@ -1,7 +1,7 @@
 --- ChainableTemporaryCredentials class.
 -- @classmod ChainableTemporaryCredentials
 
-local lom = require("lxp.lom")
+local cjson = require("cjson")
 
 
 -- Create class
@@ -117,19 +117,17 @@ function ChainableTemporaryCredentials:refresh()
     return nil, "request for token returned invalid body: " .. err
   end
 
-  local resp_body_lom, err = lom.parse(response.body)
-  if not resp_body_lom then
+  local data, err = cjson.decode(response.body)
+  if not data then
     return nil, "failed to parse response body: " .. err
   end
-
-  local cred_lom = lom.find_elem(lom.find_elem(resp_body_lom, "AssumeRoleResult"), "Credentials")
-
-  local AccessKeyId = lom.find_elem(cred_lom, "AccessKeyId")[1]
-  local SecretAccessKey = lom.find_elem(cred_lom, "SecretAccessKey")[1]
-  local SessionToken = lom.find_elem(cred_lom, "SessionToken")[1]
-  local Expiration = lom.find_elem(cred_lom, "Expiration")[1]
-
-  self:set(AccessKeyId, SecretAccessKey, SessionToken, Expiration)
+  local credentials = data.AssumeRoleResponse.AssumeRoleResult.Credentials
+  self:set(
+    credentials.AccessKeyId,
+    credentials.SecretAccessKey,
+    credentials.SessionToken,
+    credentials.Expiration
+  )
 
   return true
 end

--- a/src/resty/aws/credentials/TokenFileWebIdentityCredentials.lua
+++ b/src/resty/aws/credentials/TokenFileWebIdentityCredentials.lua
@@ -83,7 +83,7 @@ function TokenFileWebIdentityCredentials:refresh()
   if not data then
     return nil, "failed to parse response body: " .. err
   end
-  local credentials = data.AssumeRoleResponse.AssumeRoleResult.Credentials
+  local credentials = data.AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials
   self:set(
     credentials.AccessKeyId,
     credentials.SecretAccessKey,

--- a/src/resty/aws/request/build.lua
+++ b/src/resty/aws/request/build.lua
@@ -139,7 +139,7 @@ local function build_request(operation, config, params)
     path =  uri,
     method = http.method,
     query = {},
-    headers = { ["Host"] = host_header, },
+    headers = { ["Host"] = host_header, ["Accept"] = "application/json" },
     host = host,
     port = port,
   }


### PR DESCRIPTION
Some Lua files are using the XML-based AWS STS API, and they require bindings based on the libexpat c library to parse the XML, which requires that the expat library be installed for OpenResty; this library has a specific requirement for a version of the expat codebase, which is not available in the repositories of the major Linux distributions, and can only be installed from source. This creates a barrier to building and distributing the software.

However that the AWS STS API doesn't have to use XML as a response format, it also supports JSON, allowing us to parse it directly in cjson.

This PR makes the change to remove the expat dependency and change the two Credentials methods that currently rely on XML to JSON. This will modify the request headers on all service API calls, but is not expected to have an impact since those APIs originally used JSON.