### PR TITLE
fix(request): remove unescape operation for user-input query params when building canonical querystring

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ Release process:
 1. upload using: `VERSION=x.y.z APIKEY=abc... make upload`
 1. test installing the rock from LuaRocks
 
+### Unreleased
+
+- fix: fix an issue when publish sns message with urlencode reserved character(+/%)
+  [132](https://github.com/Kong/lua-resty-aws/pull/132)
 
 ### 1.5.4 (23-Sep-2024)
 

--- a/spec/02-requests/02-build_request_spec.lua
+++ b/spec/02-requests/02-build_request_spec.lua
@@ -136,6 +136,36 @@ describe("operations protocol", function()
       },
     }
 
+    operation_with_requestUri_params_and_query_param_input = {
+      name = "PutObject",
+      http = {
+        method = "PUT",
+        requestUri = "/{Bucket}/{Key+}?testparam=testparamvalue"
+      },
+      input = {
+        type = "structure",
+        required = {
+          "Bucket",
+          "Key"
+        },
+        members = {
+          TestMember = {
+            type = "string",
+          },
+          Bucket = {
+            type = "string",
+            location = "uri",
+            locationName = "Bucket"
+          },
+          Key = {
+            type = "string",
+            location = "uri",
+            locationName = "Key"
+          },
+        },
+      },
+    }
+
     config = {
       apiVersion = "2011-06-15",
       --endpointPrefix = "sts",
@@ -184,6 +214,12 @@ describe("operations protocol", function()
       Body = binary_data,
     }
 
+    params_with_requestUri_params_and_query_param_input = {
+      Bucket = "hello",
+      Key = "world",
+      TestMember = "testvalue",
+    }
+
   end)
 
 
@@ -224,6 +260,30 @@ describe("operations protocol", function()
         BinaryData = binary_data,
       }
     }, request)
+  end)
+
+  it("query: undefined location params go into query table, with requestUri query params added", function ()
+    config_with_payload.protocol = "query"
+
+    local request = build_request(operation_with_requestUri_params_and_query_param_input,
+                                  config_with_payload, params_with_requestUri_params_and_query_param_input)
+    assert.same({
+      headers = {
+        ["X-Amz-Target"] = "s3.PutObject",
+        ["Host"] = "s3.amazonaws.com",
+      },
+      method = 'PUT',
+      path = '/hello/world',
+      host = 's3.amazonaws.com',
+      port = 443,
+      query = {
+        Action = "PutObject",
+        Version = "2006-03-01",
+        testparam = "testparamvalue",
+        TestMember = "testvalue",
+      }
+    }, request)
+
   end)
 
 

--- a/spec/04-services/06-sns_spec.lua
+++ b/spec/04-services/06-sns_spec.lua
@@ -1,0 +1,80 @@
+setmetatable(_G, nil)
+
+local AWS = require("resty.aws")
+local AWS_global_config = require("resty.aws.config").global
+
+
+local config = AWS_global_config
+config.tls = true
+local aws = AWS(config)
+
+
+aws.config.credentials = aws:Credentials {
+  accessKeyId = "test_id",
+  secretAccessKey = "test_key",
+}
+
+aws.config.region = "test_region"
+aws.config.dry_run = true
+
+describe("SNS service", function()
+  local sns
+  local origin_time
+
+  setup(function()
+    origin_time = ngx.time
+    ngx.time = function () --luacheck: ignore
+      return 1667543171
+    end
+  end)
+
+  teardown(function ()
+    ngx.time = origin_time --luacheck: ignore
+  end)
+
+  before_each(function()
+    sns = assert(aws:SNS({}))
+  end)
+
+  after_each(function()
+  end)
+
+  local testcases = {
+    publish = {
+      {
+        TopicArn = "arn:aws:sns:test-region:000000000000:test-topic",
+        Message = '{"timestamp":"1980-01-02T08:11:12.123+01:00","message":"test%abc%22"}',  -- this is not an urlencoded message value
+      },
+      {
+        ['headers'] = {
+          ['Authorization'] = 'AWS4-HMAC-SHA256 Credential=test_id/20221104/test_region/sns/aws4_request, SignedHeaders=host;x-amz-date, Signature=9a83a7bafbccd6c3214091baf22eb1d1e507327be18f7ad5cf8ccc45ac335e48',
+          ['Host'] = 'sns.test_region.amazonaws.com',
+          ['X-Amz-Date'] = '20221104T062611Z',
+        },
+        ['host'] = 'sns.test_region.amazonaws.com',
+        ['method'] = 'POST',
+        ['path'] = '/',
+        ['proxy_opts'] = {},
+        ['port'] = 443,
+        ['query'] = {
+          ['Action'] = 'Publish',
+          ['Version'] = '2010-03-31',
+          ['Message'] = '{"timestamp":"1980-01-02T08:11:12.123+01:00","message":"test%abc%22"}',
+          ['TopicArn'] = 'arn:aws:sns:test-region:000000000000:test-topic',
+        },
+        ['tls'] = true,
+      },
+    },
+  }
+
+  for api, test in pairs(testcases) do
+    it("SecretsManager:" .. api, function()
+      local param = test[1]
+      local expected_result_aws = test[2]
+
+      local result_aws = assert(sns[api](sns, param))
+
+      assert.same(expected_result_aws, result_aws)
+    end)
+  end
+end)

--- a/src/resty/aws/request/build.lua
+++ b/src/resty/aws/request/build.lua
@@ -202,7 +202,7 @@ local function build_request(operation, config, params)
   request.path = path
 
   for k,v in pairs(parse_query(query)) do
-    request.query[k] = v
+    request.query[ngx.unescape_uri(k)] = ngx.unescape_uri(v)
   end
 
   local payload_member = operation.input and operation.input.payload

--- a/src/resty/aws/request/signatures/utils.lua
+++ b/src/resty/aws/request/signatures/utils.lua
@@ -73,8 +73,8 @@ local function canonicalise_query_string(query)
 
   elseif type(query) == "table" then
     for key, val in pairs(query) do
-      key = ngx.unescape_uri(key):gsub("[^%w%-%._~]", percent_encode)
-      val = ngx.unescape_uri(val):gsub("[^%w%-%._~]", percent_encode)
+      key = key:gsub("[^%w%-%._~]", percent_encode)
+      val = val:gsub("[^%w%-%._~]", percent_encode)
       q[#q+1] = key .. "=" .. val
     end
 


### PR DESCRIPTION
## Summary

This PR fixes a 403 issue when user-input query params contains some reserved characters for urlencode.

https://konghq.atlassian.net/browse/FTI-6288 is the original report where user failed to call SNS service "Publish" operation to send a message with "+" or "%".

This PR fixes the issue that when the request is being built, query params in AWS API doc's`requestUri` will be unescaped, and user-input query params will not getting unescaped when signing request.